### PR TITLE
core: derive additional traits for exposed types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,12 +57,12 @@ use std::fs::File;
 mod error;
 pub use error::Error;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Pin {
     pin_num: u64,
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Direction {
     In,
     Out,
@@ -70,7 +70,7 @@ pub enum Direction {
     Low,
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Edge {
     NoInterrupt,
     RisingEdge,


### PR DESCRIPTION
This is useful for users of these types in external
libraries who may want to be able to use these types in various
ways (for instance, I bumped into some isses with traits not
being implemented in gpio-utils).

Signed-off-by: Paul Osborne <osbpau@gmail.com>