### PR TITLE
docs: fix link to rustdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ rust-sysfs-gpio
 [![Version](https://img.shields.io/crates/v/sysfs-gpio.svg)](https://crates.io/crates/sysfs-gpio)
 [![License](https://img.shields.io/crates/l/sysfs-gpio.svg)](https://github.com/rust-embedded/rust-sysfs-gpio/blob/master/README.md#license)
 
-- [API Documentation](http://posborne.github.io/rust-sysfs-gpio/)
+- [API Documentation](http://rust-embedded.github.io/rust-sysfs-gpio/sysfs_gpio/index.html)
 
 rust-sysfs-gpio is a rust library/crate providing access to the Linux
 sysfs GPIO interface (https://www.kernel.org/doc/Documentation).  It


### PR DESCRIPTION
Now that we are generating docs for changes coming into
master, it is probably best to have docs that are up-to-date.

CC @nastevens