### PR TITLE
sleep_ms is deprecated since 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ fn main() {
     my_led.with_exported(|| {
         loop {
             my_led.set_value(0).unwrap();
-            sleep_ms(Duration::from_millis(200));
+            sleep(Duration::from_millis(200));
             my_led.set_value(1).unwrap();
-            sleep_ms(Duration::from_millis(200));
+            sleep(Duration::from_millis(200));
         }
     }).unwrap();
 }


### PR DESCRIPTION
according to https://doc.rust-lang.org/std/thread/fn.sleep_ms.html and
the use line above uses sleep. This fixes this for first time users of the library.