### PR TITLE
Improve from_file path handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.4.0
+  - 1.5.0
   - stable
   - beta
   - nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use std::os::unix::prelude::*;
 use std::io::{self, SeekFrom};
 use std::fs;
 use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 mod error;
 pub use error::Error;
@@ -149,13 +149,8 @@ impl Pin {
     /// a path starting with /sys/class/gpioXXX), then this function
     /// will return an error.
     pub fn from_path<T: AsRef<Path>>(path: T) -> Result<Pin> {
-        // TODO: use something like realpath once available.
-        // See https://github.com/rust-lang/rfcs/issues/939 and
-        // https://github.com/rust-lang/rust/issues/11857
-        let mut pb = PathBuf::from(path.as_ref());
-        while try!(fs::metadata(&pb)).file_type().is_symlink() {
-            pb = try!(fs::read_link(pb));
-        }
+        // Resolve all symbolic links in the provided path
+        let pb = try!(fs::canonicalize(path.as_ref()));
 
         // determine if this is valid and figure out the pin_num
         if !try!(fs::metadata(&pb)).is_dir() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ impl Pin {
                                                   a directory")));
         }
 
-        let re = regex::Regex::new(r"^/sys/class/gpio/gpio(\d+)$").unwrap();
+        let re = regex::Regex::new(r"^/sys/.*?/gpio/gpio(\d+)$").unwrap();
         let caps = match re.captures(pb.to_str().unwrap_or("")) {
             Some(cap) => cap,
             None => return Err(Error::InvalidPath(format!("{:?}", pb))),


### PR DESCRIPTION
I encountered a couple of bugs in the library while working with an i.MX6 SoC using Yocto. First, the function `Pin::from_path` was not resolving my exported GPIO at `/var/run/gpio` because Yocto had made `/var/run` itself a symlink, and the previous logic only expanded symlinks at the end of the path. Second, once I had fixed the first issue, I was unable to using `Pin::from_path` because the fully expanded path with all symlinks resolved was not neatly `/var/run/gpio/gpio(\d+)`. Instead, it included a lot of other SoC paths i.e. `/sys/devices/soc0/soc.2/2000000.aips-bus/20a8000.gpio/gpio/gpio101`

The included commits resolve both issues.

CC @posborne 