### PR TITLE
Added Copy to Pin and enums

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,12 +78,12 @@ use tokio_core::reactor::{Handle, PollEvented};
 mod error;
 pub use error::Error;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Pin {
     pin_num: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Direction {
     In,
     Out,
@@ -91,7 +91,7 @@ pub enum Direction {
     Low,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Edge {
     NoInterrupt,
     RisingEdge,


### PR DESCRIPTION
Makes sense that small enums or a small structure (only a u64) can be copied directly using the `Copy` trait. This should [speed up](https://medium.com/@robertgrosse/how-copying-an-int-made-my-code-11-times-faster-f76c66312e0f) certain operations.