### PR TITLE
Fixed a bunch of clippy warnings and errors

### DIFF
--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -6,7 +6,6 @@
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use]
 extern crate sysfs_gpio;
 
 use sysfs_gpio::{Direction, Pin};

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -24,7 +24,7 @@ fn interrupt(pin: u64) -> sysfs_gpio::Result<()> {
                 Some(value) => println!("{}", value),
                 None => {
                     let mut stdout = stdout();
-                    try!(stdout.write(b"."));
+                    try!(stdout.write_all(b"."));
                     try!(stdout.flush());
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,8 +172,8 @@ impl Pin {
 
         // determine if this is valid and figure out the pin_num
         if !try!(fs::metadata(&pb)).is_dir() {
-            return Err(Error::Unexpected(format!("Provided path not a directory or symlink to \
-                                                  a directory")));
+            return Err(Error::Unexpected("Provided path not a directory or symlink to \
+                                          a directory".to_owned()));
         }
 
         let re = regex::Regex::new(r"^/sys/.*?/gpio/gpio(\d+)$").unwrap();
@@ -268,7 +268,7 @@ impl Pin {
     /// }
     /// ```
     pub fn export(&self) -> Result<()> {
-        if let Err(_) = fs::metadata(&format!("/sys/class/gpio/gpio{}", self.pin_num)) {
+        if fs::metadata(&format!("/sys/class/gpio/gpio{}", self.pin_num)).is_err() {
             let mut export_file = try!(File::create("/sys/class/gpio/export"));
             try!(export_file.write_all(format!("{}", self.pin_num).as_bytes()));
         }
@@ -282,7 +282,7 @@ impl Pin {
     /// exported, it will return without error.  That is, whenever
     /// this function returns Ok, the GPIO is not exported.
     pub fn unexport(&self) -> Result<()> {
-        if let Ok(_) = fs::metadata(&format!("/sys/class/gpio/gpio{}", self.pin_num)) {
+        if fs::metadata(&format!("/sys/class/gpio/gpio{}", self.pin_num)).is_ok() {
             let mut unexport_file = try!(File::create("/sys/class/gpio/unexport"));
             try!(unexport_file.write_all(format!("{}", self.pin_num).as_bytes()));
         }


### PR DESCRIPTION
Makes sense to use Clippy to check for common errors. This should make the code faster, and more idiomatic.