### PR TITLE
Bumped version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysfs_gpio"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-sysfs-gpio"


### PR DESCRIPTION
Bumped version number so that latest changes can make it to crates.io.