### PR TITLE
Remove regexp dependency with custom path match function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,5 @@ tokio = ["futures", "tokio-core", "mio-evented"]
 [dependencies]
 futures = { version = "0.1", optional = true }
 nix = "0.6.0"
-regex = "0.1.0"
 mio = { version = "0.6", optional = true }
 tokio-core = { version = "0.1", optional = true }


### PR DESCRIPTION
Hello there.
You  know adding more dependencies is not a good idea especially for low level libraries.
I think that in your project regexp dependency (with its transition dependencies) is a little bit redundant, because it required only once in a code.

Now in --build release you have only 4.8M dependencies in target/release/deps/
With regexp it was about 13M

