### PR TITLE
Relax extract pin from path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.20.0
+  - 1.21.0
   - stable
   - beta
   - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [master] - Unreleased
 
+## [0.5.3] - 2018-04-19
+
 ### Fixed
 
 - Relaxed path restrictions on `Pin::from_path` to allow for directories
@@ -164,7 +166,8 @@
 - Initial version of the library with basic functionality
 - Support for `export`/`unexport`/`get_value`/`set_value`/`set_direction`
 
-[master]: https://github.com/posborne/rust-sysfs-gpio/compare/0.5.2...master
+[master]: https://github.com/posborne/rust-sysfs-gpio/compare/0.5.3...master
+[0.5.3]: https://github.com/posborne/rust-sysfs-gpio/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/posborne/rust-sysfs-gpio/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/posborne/rust-sysfs-gpio/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/posborne/rust-sysfs-gpio/compare/0.4.4...0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [master] - Unreleased
 
+### Fixed
+
+- Relaxed path restrictions on `Pin::from_path` to allow for directories
+  outside of `/sys/class/gpio`, required for some SOCs that symlink outside of
+  that directory.
+
 ## [0.5.2] - 2018-03-02
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysfs_gpio"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-sysfs-gpio"


### PR DESCRIPTION
The logic of extract_pin_from_path is too rigid, expecting GPIOs to only exist at the "/sys/class/gpio" path. The problem with this is that the kernel may actually symlink the directory in "/sys/class/gpio" to a chip or SOC-specific path, and the logic prior to extracting the pin from the path performs a canonicalization, breaking the assumption.

So, for example, the following is the output of a gpio on the board I'm working with, which fails with the current check:

    root# readlink /var/run/gpio/hwid-0
        /sys/class/gpio/gpio122

    root# readlink /sys/class/gpio/gpio122
        ../../devices/soc0/soc/2000000.aips-bus/20a8000.gpio/gpiochip3/gpio/gpio122

This PR fixes the issue by relaxing the restrictions of extract_pin_from_path to only look for a final file component that looks like "gpioXXXX".

I also bumped the minimum Rust version to 1.21.0 to fix CI build failures, and made changes for 0.5.3 release (hint hint).