### PR TITLE
Replace the `description` field with the readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,8 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-sysfs-gpio"
 homepage = "https://github.com/rust-embedded/rust-sysfs-gpio"
 documentation = "http://rust-embedded.github.io/rust-sysfs-gpio/"
-description = """
-Provides access to the Linux sysfs interface to GPIOs.
-Via the `sysfs_gpio` crate you can export, unexport,
-set the direction, read, write, and poll (using
-interrupts) GPIOs from userspace.
-
-See https://www.kernel.org/doc/Documentation/gpio/sysfs.txt
-"""
+description = "Provides access to GPIOs using the Linux sysfs interface."
+readme = "README.md"
 
 [features]
 mio-evented = ["mio"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-rust-sysfs-gpio
-===============
+sysfs_gpio
+==========
 
 [![Build Status](https://travis-ci.org/rust-embedded/rust-sysfs-gpio.svg?branch=master)](https://travis-ci.org/rust-embedded/rust-sysfs-gpio)
 [![Version](https://img.shields.io/crates/v/sysfs-gpio.svg)](https://crates.io/crates/sysfs-gpio)
@@ -7,9 +7,10 @@ rust-sysfs-gpio
 
 - [API Documentation](https://docs.rs/sysfs_gpio)
 
-rust-sysfs-gpio is a rust library/crate providing access to the Linux
-sysfs GPIO interface (https://www.kernel.org/doc/Documentation).  It
-seeks to provide an API that is safe, convenient, and efficient.
+The `sysfs_gpio` crate provides access to the Linux sysfs GPIO interface
+(https://www.kernel.org/doc/Documentation/gpio/sysfs.txt). It seeks to provide
+an API that is safe, convenient, and efficient and supports exporting,
+unexporting, reading, writing and waiting for interrupts on pins.
 
 Many devices such as the Raspberry Pi or Beaglebone Black provide
 userspace access to a number of GPIO peripherals.  The standard kernel


### PR DESCRIPTION
crates.io will render the file specified in the `readme` field in place
of the description, so use the latter as a short single-line
description instead.