### PR TITLE
Bump minimum rustc to 1.26.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.21.0
+  - 1.26.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Tested on my fork, in the branch 'travis' you can find the README badge pointing to my own Travis build where it states that it's passing.

Fixes #53.