### PR TITLE
bump nix to 0.14 to fix compilation issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysfs_gpio"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-embedded/rust-sysfs-gpio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ use_tokio = ["futures", "tokio", "mio-evented"]
 
 [dependencies]
 futures = { version = "0.1", optional = true }
-nix = "0.10.0"
+nix = "0.14.0"
 mio = { version = "0.6", optional = true }
 tokio = { version = "0.1", optional = true }


### PR DESCRIPTION
~Waiting on: https://github.com/nix-rust/nix/issues/1060#issuecomment-494627579~
See also: https://github.com/rust-embedded/linux-embedded-hal/pull/17
Patching to git source tested to be working