### PR TITLE
Add missing set_direction in main example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ use std::time::Duration;
 fn main() {
     let my_led = Pin::new(127); // number depends on chip, etc.
     my_led.with_exported(|| {
+        my_led.set_direction(Direction::Out).unwrap();
         loop {
             my_led.set_value(0).unwrap();
             sleep(Duration::from_millis(200));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! fn main() {
 //!     let my_led = Pin::new(127); // number depends on chip, etc.
 //!     my_led.with_exported(|| {
+//!         my_led.set_direction(Direction::Out).unwrap();
 //!         loop {
 //!             my_led.set_value(0).unwrap();
 //!             sleep(Duration::from_millis(200));


### PR DESCRIPTION
Was getting an "Operation not permitted" and realized the example code wasn't setting the direction.
Actually, the use statement was already there, printing a friendly warning:
```
use sysfs_gpio::{Direction, Pin};
```

Thanks!