### PR TITLE
Run rustfmt and fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Cargo.lock
 
 # Intellij IDEA
 .idea
+
+# macOS DS_Store files
+.DS_Store

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -8,10 +8,10 @@
 
 extern crate sysfs_gpio;
 
-use sysfs_gpio::{Direction, Pin};
-use std::time::Duration;
-use std::thread::sleep;
 use std::env;
+use std::thread::sleep;
+use std::time::Duration;
+use sysfs_gpio::{Direction, Pin};
 
 struct Arguments {
     pin: u64,
@@ -58,20 +58,18 @@ fn get_args() -> Option<Arguments> {
         Err(_) => return None,
     };
     Some(Arguments {
-             pin: pin,
-             duration_ms: duration_ms,
-             period_ms: period_ms,
-         })
+        pin: pin,
+        duration_ms: duration_ms,
+        period_ms: period_ms,
+    })
 }
 
 fn main() {
     match get_args() {
         None => print_usage(),
-        Some(args) => {
-            match blink_my_led(args.pin, args.duration_ms, args.period_ms) {
-                Ok(()) => println!("Success!"),
-                Err(err) => println!("We have a blinking problem: {}", err),
-            }
-        }
+        Some(args) => match blink_my_led(args.pin, args.duration_ms, args.period_ms) {
+            Ok(()) => println!("Success!"),
+            Err(err) => println!("We have a blinking problem: {}", err),
+        },
     }
 }

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -8,10 +8,10 @@
 
 extern crate sysfs_gpio;
 
-use sysfs_gpio::{Direction, Edge, Pin};
 use std::env;
 use std::io::prelude::*;
 use std::io::stdout;
+use sysfs_gpio::{Direction, Edge, Pin};
 
 fn interrupt(pin: u64) -> sysfs_gpio::Result<()> {
     let input = Pin::new(pin);
@@ -38,12 +38,10 @@ fn main() {
         println!("Usage: ./interrupt <pin>");
     } else {
         match args[1].parse::<u64>() {
-            Ok(pin) => {
-                match interrupt(pin) {
-                    Ok(()) => println!("Interrupting Complete!"),
-                    Err(err) => println!("Error: {}", err),
-                }
-            }
+            Ok(pin) => match interrupt(pin) {
+                Ok(()) => println!("Interrupting Complete!"),
+                Err(err) => println!("Error: {}", err),
+            },
             Err(_) => println!("Usage: ./interrupt <pin>"),
         }
     }

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -8,10 +8,10 @@
 
 extern crate sysfs_gpio;
 
-use sysfs_gpio::{Direction, Pin};
 use std::env;
 use std::thread::sleep;
 use std::time::Duration;
+use sysfs_gpio::{Direction, Pin};
 
 fn poll(pin_num: u64) -> sysfs_gpio::Result<()> {
     // NOTE: this currently runs forever and as such if
@@ -40,12 +40,10 @@ fn main() {
         println!("Usage: ./poll <pin>");
     } else {
         match args[1].parse::<u64>() {
-            Ok(pin) => {
-                match poll(pin) {
-                    Ok(()) => println!("Polling Complete!"),
-                    Err(err) => println!("Error: {}", err),
-                }
-            }
+            Ok(pin) => match poll(pin) {
+                Ok(()) => println!("Polling Complete!"),
+                Err(err) => println!("Error: {}", err),
+            },
             Err(_) => println!("Usage: ./poll <pin>"),
         }
     }

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -9,7 +9,7 @@ extern crate tokio;
 use std::env;
 
 #[cfg(feature = "use_tokio")]
-use futures::{Future, lazy, Stream};
+use futures::{lazy, Future, Stream};
 
 #[cfg(feature = "use_tokio")]
 use sysfs_gpio::{Direction, Edge, Pin};
@@ -27,12 +27,15 @@ fn stream(pin_nums: Vec<u64>) -> sysfs_gpio::Result<()> {
             pin.export().unwrap();
             pin.set_direction(Direction::In).unwrap();
             pin.set_edge(Edge::BothEdges).unwrap();
-            tokio::spawn(pin.get_value_stream().unwrap()
-                .for_each(move |val| {
-                    println!("Pin {} changed value to {}", i, val);
-                    Ok(())
-                })
-                .map_err(|_| ()));
+            tokio::spawn(
+                pin.get_value_stream()
+                    .unwrap()
+                    .for_each(move |val| {
+                        println!("Pin {} changed value to {}", i, val);
+                        Ok(())
+                    })
+                    .map_err(|_| ()),
+            );
         }
         Ok(())
     });

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
+use nix;
 use std::convert;
 use std::fmt;
 use std::io;
-use nix;
 
 #[derive(Debug)]
 pub enum Error {
@@ -43,7 +43,6 @@ impl fmt::Display for Error {
         }
     }
 }
-
 
 impl convert::From<io::Error> for Error {
     fn from(e: io::Error) -> Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ impl ::std::error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&::std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ impl Pin {
         path.as_ref()
             .file_name()
             .and_then(|filename| filename.to_str())
-            .and_then(|filename_str| filename_str.trim_left_matches("gpio").parse::<u64>().ok())
+            .and_then(|filename_str| filename_str.trim_start_matches("gpio").parse::<u64>().ok())
             .ok_or(Error::InvalidPath(format!("{:?}", path.as_ref())))
     }
 
@@ -223,7 +223,7 @@ impl Pin {
         self.export()?;
         match closure() {
             Ok(()) => {
-                try!(self.unexport());
+                self.unexport()?;
                 Ok(())
             }
             Err(err) => {
@@ -571,7 +571,7 @@ impl PinPoller {
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
-    pub fn new(pin_num: u64) -> Result<PinPoller> {
+    pub fn new(_pin_num: u64) -> Result<PinPoller> {
         Err(Error::Unsupported("PinPoller".into()))
     }
 
@@ -605,7 +605,7 @@ impl PinPoller {
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
-    pub fn poll(&mut self, timeout_ms: isize) -> Result<Option<u8>> {
+    pub fn poll(&mut self, _timeout_ms: isize) -> Result<Option<u8>> {
         Err(Error::Unsupported("PinPoller".into()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,10 @@ extern crate tokio;
 
 use std::fs;
 use std::fs::File;
+use std::io;
 use std::io::prelude::*;
-use std::io::{self, SeekFrom};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::io::SeekFrom;
 use std::os::unix::prelude::*;
 use std::path::Path;
 
@@ -113,12 +115,14 @@ pub type Result<T> = ::std::result::Result<T, error::Error>;
 /// Typically, one would just use seek() for this sort of thing,
 /// but for certain files (e.g. in sysfs), you need to actually
 /// read it.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn flush_input_from_file(dev_file: &mut File, max: usize) -> io::Result<usize> {
     let mut s = String::with_capacity(max);
     dev_file.read_to_string(&mut s)
 }
 
 /// Get the pin value from the provided file
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn get_value_from_file(dev_file: &mut File) -> Result<u8> {
     let mut s = String::with_capacity(10);
     dev_file.seek(SeekFrom::Start(0))?;


### PR DESCRIPTION
Most warnings were about deprecated fns, but some were about unused arguments in other platforms.

Two unused fn warnings remained, used only in `#[cfg(any(target_os = "linux", target_os = "android"))]` fns, and I'm not sure what to do about them:

`flush_input_from_file` and `get_value_from_file`

Thanks for your time!