### PR TITLE
MSRV 1.31

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - 1.26.0
+  - 1.31.1
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-sudo: false
 rust:
   - 1.31.1
   - stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Migrated to 'tokio' crate. 
+- Minimmum supported Rust version updated to 1.31
 
 ## [0.5.3] - 2018-04-19
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ The following features are planned for the library:
 - [x] Support for asynchronous polling using `mio` or `tokio` (requires
       enabling the `mio-evented` or `use_tokio` crate features, respectively)
 
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.31 and up.  It *might*
+compile with older versions but that may change in any new patch release.
+
 ## Cross Compiling
 
 Most likely, the machine you are running on is not your development


### PR DESCRIPTION
CI has been failing for a while because of a change to `cfg-if` that increased the MSRV but only changed the patch version. It's probably reasonable to update anyway and open the door to Rust 2018 edition.