### PR TITLE
Fix compilation with use_tokio feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ use std::fs;
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", feature = "use_tokio"))]
 use std::io::SeekFrom;
 use std::os::unix::prelude::*;
 use std::path::Path;
@@ -123,7 +123,7 @@ fn flush_input_from_file(dev_file: &mut File, max: usize) -> io::Result<usize> {
 }
 
 /// Get the pin value from the provided file
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", feature = "use_tokio"))]
 fn get_value_from_file(dev_file: &mut File) -> Result<u8> {
     let mut s = String::with_capacity(10);
     dev_file.seek(SeekFrom::Start(0))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ macro_rules! try_unexport {
         match $e {
             Ok(res) => res,
             Err(e) => {
-                try!($gpio.unexport());
+                $gpio.unexport()?;
                 return Err(e);
             }
         }
@@ -217,8 +217,8 @@ impl Pin {
     /// let gpio = Pin::new(24);
     /// let res = gpio.with_exported(|| {
     ///     println!("At this point, the Pin is exported");
-    ///     try!(gpio.set_direction(Direction::Low));
-    ///     try!(gpio.set_value(1));
+    ///     gpio.set_direction(Direction::Low)?;
+    ///     gpio.set_value(1)?;
     ///     // ...
     ///     Ok(())
     /// });
@@ -731,7 +731,7 @@ impl Stream for PinValueStream {
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         match self.0.poll() {
             Ok(Async::Ready(Some(()))) => {
-                let value = try!(self.get_value());
+                let value = self.get_value()?;
                 Ok(Async::Ready(Some(value)))
             }
             Ok(Async::Ready(None)) => Ok(Async::Ready(None)),


### PR DESCRIPTION
Apparently I've introduced a regression in #58 (sorry!) because I didn't run the tests with features (and travis didn't run as seen in https://github.com/rust-embedded/rust-sysfs-gpio/pull/59#issuecomment-593207289).

This fixes that regression by compiling `get_value_from_file` also when `feature = "use_tokio"`.

I also took the opportunity to use `?` instead of all remaining `try!()` macros.