### PR TITLE
Fix feature name tokio->use_tokio in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,13 @@ env:
 
 script:
   - |
-    travis-cargo build -- --features=tokio &&
-    travis-cargo test -- --features=tokio &&
+    travis-cargo build -- --features=use_tokio &&
+    travis-cargo test -- --features=use_tokio &&
     travis-cargo build -- --features=mio-evented &&
     travis-cargo test -- --features=mio-evented &&
     travis-cargo build -- &&
     travis-cargo test -- &&
-    travis-cargo --only stable doc -- --features=tokio
+    travis-cargo --only stable doc -- --features=use_tokio
 
 after_success:
   - '[ $TRAVIS_OS_NAME == linux ] && travis-cargo coveralls --no-sudo --verify'


### PR DESCRIPTION
After finding the regression I fixed in #61 I was very surprised that travis managed to compile #60 just fine on macOS (stable) and tried building it on my machine (which failed). 

Then I realised that the config file was using `--features tokio` instead of `use_tokio`.