### PR TITLE
Allow nix 0.23.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [master] - Unreleased
 
+### Changed
+
+- Updated nix to allow both version `0.22` or `0.23`.
+
 ## [0.6.0] - 2021-09-24
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ async-tokio = ["futures", "tokio", "mio-evented"]
 
 [dependencies]
 futures = { version = "0.3", optional = true }
-nix = "0.22"
+nix = ">= 0.22, < 0.24"
 mio = { version = "0.7", optional = true, features = ["os-ext"]}
 tokio = { version = "1", optional = true, features = ["net"] }
 


### PR DESCRIPTION
This crate compiles fine with nix 0.23 too. This change allows both nix 0.22 and 0.23 as dependency.