### PR TITLE
Fix codeowners + update dependencies + raise MSRV

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* rust-embedded/embedded-linux
+* @rust-embedded/embedded-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
         include:
           # MSRV
-          - rust: 1.65.0
+          - rust: 1.70.0
             TARGET: x86_64-unknown-linux-gnu
 
           # Test nightly but don't fail
@@ -109,10 +109,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.70.0
           components: clippy
 
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- Updated `mio` to version `1`.
+- Updated `nix` to version `0.26`.
+- Minimum supported Rust version updated to 1.70.0
+
 ## [0.6.2] - 2024-05-13
 
 - Minimum supported Rust version updated to 1.65.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/rust-embedded/rust-sysfs-gpio"
 documentation = "https://docs.rs/sysfs_gpio/"
 description = "Provides access to GPIOs using the Linux sysfs interface."
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [features]
 mio-evented = ["mio"]
@@ -19,8 +19,8 @@ async-tokio = ["futures", "tokio", "mio-evented"]
 
 [dependencies]
 futures = { version = "0.3", optional = true }
-nix = "0.23"
-mio = { version = "0.8", optional = true, features = ["os-ext"]}
+nix = "0.26"
+mio = { version = "1", optional = true, features = ["os-ext"]}
 tokio = { version = "1", optional = true, features = ["net"] }
 
 [dev-dependencies]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Paul Osborne
-Copyright (c) 2021 The Rust Embedded Linux Team
+Copyright (c) 2021-2025 The Rust Embedded Linux Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20,4 +20,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ sysfs_gpio
 
 [![Build Status](https://github.com/rust-embedded/rust-sysfs-gpio/workflows/CI/badge.svg)](https://github.com/rust-embedded/rust-sysfs-gpio/actions)
 [![Version](https://img.shields.io/crates/v/sysfs-gpio.svg)](https://crates.io/crates/sysfs-gpio)
-![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.65+-blue.svg)
+![Minimum Supported Rust Version](https://img.shields.io/badge/rustc-1.70+-blue.svg)
 [![License](https://img.shields.io/crates/l/sysfs-gpio.svg)](https://github.com/rust-embedded/rust-sysfs-gpio/blob/master/README.md#license)
 
 - [API Documentation](https://docs.rs/sysfs_gpio)
@@ -85,7 +85,7 @@ The following features are planned for the library:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.65.0 and up.  It *might*
+This crate is guaranteed to compile on stable Rust 1.70.0 and up.  It *might*
 compile with older versions but that may change in any new patch release.
 
 ## Cross Compiling


### PR DESCRIPTION
The effective MSRV before this change is already 1.70 due to dependencies so I have made this official.
`nix` could be updated further but that needs some small changes due to the deprecation of some of the functions that we use but that would need more time than I have for this at the moment.