### PR TITLE
Add conversion to io::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Minimum supported Rust version updated to 1.65.0
+- The crate's `Error` type can now be converted to a `std::io::Error` using `From` / `Into`.
 
 ## [0.6.1] - 2021-11-22
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,3 +45,14 @@ impl convert::From<nix::Error> for Error {
         Error::Io(e.into())
     }
 }
+
+impl convert::From<Error> for io::Error {
+    fn from(e: Error) -> io::Error {
+        match e {
+            Error::Io(err) => err,
+            Error::Unexpected(err) => io::Error::new(io::ErrorKind::Unsupported, err),
+            Error::InvalidPath(err) => io::Error::new(io::ErrorKind::InvalidInput, err),
+            Error::Unsupported(err) => io::Error::new(io::ErrorKind::InvalidData, err),
+        }
+    }
+}


### PR DESCRIPTION
I'm not sure if this repository is still being maintained, but the crate is still very useful when working with older Linux kernels.

This PR adds a simple implementation for mapping this crate's custom error type to `std::io::Error`. Having this impl is useful when interacting with other functions that return `std::io::Result`.
